### PR TITLE
remove unused key from stasis state Jason encoder

### DIFF
--- a/lib/ex_ari/stasis.ex
+++ b/lib/ex_ari/stasis.ex
@@ -97,7 +97,7 @@ defmodule ARI.Stasis do
     @moduledoc false
     @type t :: %__MODULE__{}
 
-    @derive {Jason.Encoder, only: [:connected, :url, :status, :type]}
+    @derive {Jason.Encoder, only: [:connected, :url, :status]}
     defstruct [
       :connected,
       :url,


### PR DESCRIPTION
This should fix the compiling error with newer versions of the Jason library.